### PR TITLE
Add prop to disable drag and drop

### DIFF
--- a/src/Kanban/index.js
+++ b/src/Kanban/index.js
@@ -52,6 +52,7 @@ class Kanban extends PureComponent {
     overscanListCount: 2,
     overscanRowCount: 2,
     itemCacheKey: ({ id }) => `${id}`,
+    dndDisabled: false,
   }
 
   static childContextTypes = {
@@ -68,7 +69,7 @@ class Kanban extends PureComponent {
     this.state = {
       lists: props.lists
     };
-
+    
     this.onMoveList = this.onMoveList.bind(this);
     this.onMoveRow = this.onMoveRow.bind(this);
 
@@ -233,6 +234,7 @@ class Kanban extends PureComponent {
         overscanRowCount={this.props.overscanRowCount}
         itemCacheKey={this.props.itemCacheKey}
         findItemIndex={this.findItemIndex}
+        dndDisabled={this.props.dndDisabled}
       />
     );
   }
@@ -248,6 +250,7 @@ class Kanban extends PureComponent {
       overscanListCount,
       scrollToList,
       scrollToAlignment,
+      dndDisabled,
     } = this.props;
 
     return (

--- a/src/Kanban/propTypes.js
+++ b/src/Kanban/propTypes.js
@@ -18,3 +18,4 @@ export const overscanRowCount = PropTypes.number;
 export const scrollToList = PropTypes.number;
 export const scrollToAlignment = PropTypes.string;
 export const itemCacheKey = PropTypes.func;
+export const dndDisabled = PropTypes.bool;

--- a/src/SortableItem/dragSpec.js
+++ b/src/SortableItem/dragSpec.js
@@ -34,3 +34,7 @@ export function isDragging({ rowId }, monitor) {
 
    return rowId === draggingRowId;
 }
+
+export function canDrag(props, monitor) {
+  return props.dndDisabled ? false : true;
+}

--- a/src/SortableItem/propTypes.js
+++ b/src/SortableItem/propTypes.js
@@ -9,6 +9,7 @@ export const itemComponent = PropTypes.func;
 export const moveRow = PropTypes.func;
 export const dragEndRow = PropTypes.func;
 export const dropRow = PropTypes.func;
+export const dndDisabled = PropTypes.bool.isRequired;
   // React DnD
 export const isDragging = PropTypes.bool;
 export const connectDropTarget = PropTypes.func;

--- a/src/SortableList/index.js
+++ b/src/SortableList/index.js
@@ -54,6 +54,7 @@ class SortableList extends PureComponent {
         dragBeginRow={this.props.dragBeginRow}
         dragEndRow={this.props.dragEndRow}
         findItemIndex={this.props.findItemIndex}
+        dndDisabled={this.props.dndDisabled}
       />
     );
   }

--- a/src/SortableList/propTypes.js
+++ b/src/SortableList/propTypes.js
@@ -13,6 +13,7 @@ export const dropList = PropTypes.func;
 export const dragEndRow = PropTypes.func;
 export const overscanRowCount = PropTypes.number;
 export const itemCacheKey = PropTypes.func;
+export const dndDisabled = PropTypes.bool.isRequired;
   // React DnD
 export const isDragging = PropTypes.bool;
 export const connectDropTarget = PropTypes.func;

--- a/src/demo/App.js
+++ b/src/demo/App.js
@@ -40,6 +40,7 @@ class App extends Component {
               itemCacheKey={keyGenerator}
               onMoveRow={({ lists }) => this.setState(() => ({lists}))}
               onMoveList={({ lists }) => this.setState(() => ({lists}))}
+              dndDisabled={false}
             />
           )}
         </AutoSizer>


### PR DESCRIPTION
Since task list order carries with it a lot of meaning, we need to be able to disable the kanban view while in an alternate sorted state.

To do this I'm simply passing down a bool to control whether or not the dnd is enabled. I've only applied the `canDrag` specification to the components that can actually be dragged. It seems redundant to apply it to the drag targets as well but we could consider doing it for consistency.

(see `canDrag` http://react-dnd.github.io/react-dnd/docs-drag-source.html)
